### PR TITLE
delete event 구현

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,10 +9,15 @@ import { ReviewModule } from '../review/review.module';
 import { EventModule } from 'src/event/event.module';
 import { UserModule } from '../user/user.module';
 
-
-
 @Module({
-  imports: [configModule, RegionModule, CommonModule, ReviewModule, EventModule, UserModule],
+  imports: [
+    configModule,
+    RegionModule,
+    CommonModule,
+    ReviewModule,
+    EventModule,
+    UserModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -22,8 +22,6 @@ import { EventParticipantPayload } from './payload/create-eventJoin.payload';
 import { EventQuery } from './query/event.query';
 import { PatchUpdateEventPayload } from './payload/patch-update-event.payload';
 
-
-
 @Controller('events')
 @ApiTags('Event API')
 export class EventController {
@@ -81,8 +79,4 @@ export class EventController {
   ): Promise<EventDto> {
     return this.eventService.patchUpdateEvent(eventId, payload);
   }
-
-
-
-
 }

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -24,7 +24,6 @@ import { EventQuery } from './query/event.query';
 import { PatchUpdateEventPayload } from './payload/patch-update-event.payload';
 import { PutUpdateEventPayload } from './payload/put-update-event.payload';
 
-
 @Controller('events')
 @ApiTags('Event API')
 export class EventController {
@@ -85,15 +84,11 @@ export class EventController {
 
   @Put(':eventId')
   @ApiOperation({ summary: '모임을 수정합니다' })
-  @ApiOkResponse({ type: EventDto })  
+  @ApiOkResponse({ type: EventDto })
   async putUpdateEvent(
     @Param('eventId', ParseIntPipe) eventId: number,
     @Body() payload: PutUpdateEventPayload,
   ): Promise<EventDto> {
     return this.eventService.putUpdateEvent(eventId, payload);
   }
-
-
-
-
 }

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   Param,
   ParseIntPipe,
+  Patch,
   Post,
   Query,
 } from '@nestjs/common';
@@ -19,6 +20,9 @@ import { EventDto, EventListDto } from './dto/event.dto';
 import { CreateEventPayload } from './payload/create-event.payload';
 import { EventParticipantPayload } from './payload/create-eventJoin.payload';
 import { EventQuery } from './query/event.query';
+import { PatchUpdateEventPayload } from './payload/patch-update-event.payload';
+
+
 
 @Controller('events')
 @ApiTags('Event API')
@@ -67,4 +71,18 @@ export class EventController {
   ): Promise<void> {
     return this.eventService.outEvent(eventId, payload.userId);
   }
+
+  @Patch(':eventId')
+  @ApiOperation({ summary: '모임을 수정합니다' })
+  @ApiOkResponse({ type: EventDto })
+  async patchUpdateEvent(
+    @Param('eventId', ParseIntPipe) eventId: number,
+    @Body() payload: PatchUpdateEventPayload,
+  ): Promise<EventDto> {
+    return this.eventService.patchUpdateEvent(eventId, payload);
+  }
+
+
+
+
 }

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -1,7 +1,9 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
+  HttpCode,
   Param,
   ParseIntPipe,
   Patch,
@@ -91,4 +93,22 @@ export class EventController {
   ): Promise<EventDto> {
     return this.eventService.putUpdateEvent(eventId, payload);
   }
+
+
+  @Delete(':eventId')
+  @HttpCode(204)
+  @ApiOperation({ summary: '모임을 삭제합니다.'})
+  @ApiNoContentResponse()
+  async deleteEvent(
+    @Param('eventId', ParseIntPipe) eventId: number,
+  ): Promise<void> {
+    return this.eventService.deleteEvent(eventId);
+  }
+  
+
+
+
+
+
+
 }

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -94,21 +94,13 @@ export class EventController {
     return this.eventService.putUpdateEvent(eventId, payload);
   }
 
-
   @Delete(':eventId')
   @HttpCode(204)
-  @ApiOperation({ summary: '모임을 삭제합니다.'})
+  @ApiOperation({ summary: '모임을 삭제합니다.' })
   @ApiNoContentResponse()
   async deleteEvent(
     @Param('eventId', ParseIntPipe) eventId: number,
   ): Promise<void> {
     return this.eventService.deleteEvent(eventId);
   }
-  
-
-
-
-
-
-
 }

--- a/src/event/event.controller.ts
+++ b/src/event/event.controller.ts
@@ -6,6 +6,7 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Put,
   Query,
 } from '@nestjs/common';
 import { EventService } from './event.service';
@@ -21,7 +22,7 @@ import { CreateEventPayload } from './payload/create-event.payload';
 import { EventParticipantPayload } from './payload/create-eventJoin.payload';
 import { EventQuery } from './query/event.query';
 import { PatchUpdateEventPayload } from './payload/patch-update-event.payload';
-
+import { PutUpdateEventPayload } from './payload/put-update-event.payload';
 
 
 @Controller('events')
@@ -80,6 +81,16 @@ export class EventController {
     @Body() payload: PatchUpdateEventPayload,
   ): Promise<EventDto> {
     return this.eventService.patchUpdateEvent(eventId, payload);
+  }
+
+  @Put(':eventId')
+  @ApiOperation({ summary: '모임을 수정합니다' })
+  @ApiOkResponse({ type: EventDto })  
+  async putUpdateEvent(
+    @Param('eventId', ParseIntPipe) eventId: number,
+    @Body() payload: PutUpdateEventPayload,
+  ): Promise<EventDto> {
+    return this.eventService.putUpdateEvent(eventId, payload);
   }
 
 

--- a/src/event/event.repository.ts
+++ b/src/event/event.repository.ts
@@ -7,7 +7,6 @@ import { EventQuery } from './query/event.query';
 import { PrismaClient } from '@prisma/client';
 import { UpdateEventData } from './type/update-event-data.type';
 
-
 @Injectable()
 export class EventRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -179,7 +178,6 @@ export class EventRepository {
     });
   }
 
-
   async updateEvent(
     eventId: number,
     data: UpdateEventData,
@@ -210,8 +208,4 @@ export class EventRepository {
       },
     });
   }
-
-
-
-
 }

--- a/src/event/event.repository.ts
+++ b/src/event/event.repository.ts
@@ -157,6 +157,10 @@ export class EventRepository {
     });
   }
 
+
+
+
+
   async getEvents(query: EventQuery): Promise<EventData[]> {
     return this.prisma.event.findMany({
       where: {
@@ -177,6 +181,9 @@ export class EventRepository {
       },
     });
   }
+
+
+
 
   async updateEvent(
     eventId: number,
@@ -208,4 +215,35 @@ export class EventRepository {
       },
     });
   }
+
+
+
+
+
+  async deleteEventJoin(eventid: number): Promise<void> {
+    await this.prisma.eventJoin.deleteMany({
+
+      where: {
+        id: eventid,
+      },
+
+    });
+
+  }
+
+
+
+  async deleteEvent(eventId: number): Promise<void> {
+    await this.prisma.event.delete({
+      where: {
+        id: eventId,
+      },
+    });
+  }
+  
+
+  
+
+
+
 }

--- a/src/event/event.repository.ts
+++ b/src/event/event.repository.ts
@@ -157,10 +157,6 @@ export class EventRepository {
     });
   }
 
-
-
-
-
   async getEvents(query: EventQuery): Promise<EventData[]> {
     return this.prisma.event.findMany({
       where: {
@@ -181,9 +177,6 @@ export class EventRepository {
       },
     });
   }
-
-
-
 
   async updateEvent(
     eventId: number,
@@ -216,22 +209,13 @@ export class EventRepository {
     });
   }
 
-
-
-
-
   async deleteEventJoin(eventid: number): Promise<void> {
     await this.prisma.eventJoin.deleteMany({
-
       where: {
         id: eventid,
       },
-
     });
-
   }
-
-
 
   async deleteEvent(eventId: number): Promise<void> {
     await this.prisma.event.delete({
@@ -240,10 +224,4 @@ export class EventRepository {
       },
     });
   }
-  
-
-  
-
-
-
 }

--- a/src/event/event.repository.ts
+++ b/src/event/event.repository.ts
@@ -5,6 +5,8 @@ import { EventData } from './type/event-data.type';
 import { User, Event, Category, City, EventJoin } from '@prisma/client';
 import { EventQuery } from './query/event.query';
 import { PrismaClient } from '@prisma/client';
+import { UpdateEventData } from './type/update-event-data.type';
+
 
 @Injectable()
 export class EventRepository {
@@ -176,4 +178,40 @@ export class EventRepository {
       },
     });
   }
+
+
+  async updateEvent(
+    eventId: number,
+    data: UpdateEventData,
+  ): Promise<EventData> {
+    return this.prisma.event.update({
+      where: {
+        id: eventId,
+      },
+      data: {
+        title: data.title,
+        description: data.description,
+        categoryId: data.categoryId,
+        cityId: data.cityId,
+        startTime: data.startTime,
+        endTime: data.endTime,
+        maxPeople: data.maxPeople,
+      },
+      select: {
+        id: true,
+        hostId: true,
+        title: true,
+        description: true,
+        categoryId: true,
+        cityId: true,
+        startTime: true,
+        endTime: true,
+        maxPeople: true,
+      },
+    });
+  }
+
+
+
+
 }

--- a/src/event/event.repository.ts
+++ b/src/event/event.repository.ts
@@ -209,19 +209,28 @@ export class EventRepository {
     });
   }
 
-  async deleteEventJoin(eventid: number): Promise<void> {
-    await this.prisma.eventJoin.deleteMany({
+  async deleteEventJoin(eventId: number): Promise<void> {
+    await this.prisma.event.update({
       where: {
-        id: eventid,
+        id: eventId,
+      },
+      data: {
+        eventJoin: {
+          deleteMany: {
+            eventId: eventId,
+          },
+        },
       },
     });
   }
 
-  async deleteEvent(eventId: number): Promise<void> {
+  async deleteEvent(id: number): Promise<void> {
     await this.prisma.event.delete({
       where: {
-        id: eventId,
+        id: id,
       },
     });
   }
+
+    
 }

--- a/src/event/event.repository.ts
+++ b/src/event/event.repository.ts
@@ -85,7 +85,7 @@ export class EventRepository {
           userId,
         },
         user: {
-        deletedAt: null,
+          deletedAt: null,
         },
       },
     });

--- a/src/event/event.repository.ts
+++ b/src/event/event.repository.ts
@@ -231,6 +231,4 @@ export class EventRepository {
       },
     });
   }
-
-    
 }

--- a/src/event/event.repository.ts
+++ b/src/event/event.repository.ts
@@ -46,6 +46,7 @@ export class EventRepository {
     return this.prisma.user.findUnique({
       where: {
         id: userId,
+        deletedAt: null,
       },
     });
   }
@@ -83,6 +84,9 @@ export class EventRepository {
           eventId,
           userId,
         },
+        user: {
+        deletedAt: null,
+        },
       },
     });
 
@@ -118,7 +122,6 @@ export class EventRepository {
     });
   }
 
-  //index.d.ts에서 eventJoin 에 적용가능한 aggregate count 찾았습니다!
   async getEventJoinCount(eventId: number): Promise<number> {
     return this.prisma.eventJoin.count({
       where: {

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -242,20 +242,25 @@ export class EventService {
     if (event.endTime < new Date()) {
       throw new ConflictException('이미 종료된 이벤트는 수정할 수 없습니다.');
     }
-    if (
-      !payload.startTime && payload.endTime) {
-        if( payload.endTime <event.startTime){
-          throw new ConflictException('시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.');
-        }
-      }
-    if (payload.startTime && !payload.endTime) {
-      if( payload.startTime >event.endTime){
-        throw new ConflictException('시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.');
+    if (!payload.startTime && payload.endTime) {
+      if (payload.endTime < event.startTime) {
+        throw new ConflictException(
+          '시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.',
+        );
       }
     }
-    if(payload.startTime && payload.endTime){
-      if( payload.startTime >payload.endTime){
-        throw new ConflictException('시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.');
+    if (payload.startTime && !payload.endTime) {
+      if (payload.startTime > event.endTime) {
+        throw new ConflictException(
+          '시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.',
+        );
+      }
+    }
+    if (payload.startTime && payload.endTime) {
+      if (payload.startTime > payload.endTime) {
+        throw new ConflictException(
+          '시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.',
+        );
       }
     }
 

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -135,35 +135,33 @@ export class EventService {
     eventId: number,
     payload: PatchUpdateEventPayload,
   ): Promise<EventDto> {
-    if(payload.title === null ) {
+    if (payload.title === null) {
       throw new BadRequestException('title은 null이 될 수 없습니다.');
     }
-    if(payload.description === null ) {
+    if (payload.description === null) {
       throw new BadRequestException('description은 null이 될 수 없습니다.');
     }
-    if(payload.categoryId === null ) {
+    if (payload.categoryId === null) {
       throw new BadRequestException('categoryId은 null이 될 수 없습니다.');
     }
-    if(payload.cityId === null ) {
+    if (payload.cityId === null) {
       throw new BadRequestException('cityId은 null이 될 수 없습니다.');
     }
-    if(payload.startTime === null ) {
+    if (payload.startTime === null) {
       throw new BadRequestException('startTime은 null이 될 수 없습니다.');
     }
-    if(payload.endTime === null ) {
+    if (payload.endTime === null) {
       throw new BadRequestException('endTime은 null이 될 수 없습니다.');
     }
-    if(payload.maxPeople === null ) {
+    if (payload.maxPeople === null) {
       throw new BadRequestException('maxPeople은 null이 될 수 없습니다.');
     }
-
 
     const event = await this.eventRepository.getEventById(eventId);
 
     if (!event) {
       throw new NotFoundException('Event가 존재하지 않습니다.');
     }
-
 
     const updateData: UpdateEventData = {
       title: payload.title,
@@ -179,9 +177,8 @@ export class EventService {
       eventId,
       updateData,
     );
-    
-    const eventpayload = await this.eventRepository.getEventById(eventId);
 
+    const eventpayload = await this.eventRepository.getEventById(eventId);
 
     if (!eventpayload || event.hostId !== eventpayload.hostId) {
       throw new ConflictException('host만 수정할 수 있습니다.');
@@ -194,25 +191,21 @@ export class EventService {
     if (event.endTime < new Date()) {
       throw new ConflictException('이미 종료된 이벤트는 수정할 수 없습니다.');
     }
-    if (!payload.startTime || !payload.endTime || payload.startTime > payload.endTime) {
+    if (
+      !payload.startTime ||
+      !payload.endTime ||
+      payload.startTime > payload.endTime
+    ) {
       throw new ConflictException(
         '시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.',
-      )
+      );
     }
-    if(payload.startTime < new Date()) {
+    if (payload.startTime < new Date()) {
       throw new ConflictException(
         '시작 시간이 현재 시간보다 빠르게 수정할 수 없습니다.',
       );
     }
 
-
-
     return EventDto.from(updatedEvent);
-  
   }
 }
-
-
-
-
-

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -141,6 +141,7 @@ export class EventService {
     if (!event) {
       throw new NotFoundException('Event가 존재하지 않습니다.');
     }
+    
 
     const updateData: UpdateEventData = {
       title: payload.title,
@@ -152,22 +153,31 @@ export class EventService {
       maxPeople: payload.maxPeople,
     };
 
-    const eventpayload = await this.eventRepository.getEventById(eventId);
-
-    if (!eventpayload || event.hostId !== eventpayload.hostId) {
-      throw new ConflictException('host만 수정할 수 있습니다.');
+    if(payload.maxPeople<1){
+      throw new ConflictException('maxPeople은 1이상이어야 합니다.');
     }
+
+    const category = await this.eventRepository.getCategoryById(
+      payload.categoryId,
+    );
+
+    if (!category) {
+      throw new NotFoundException('category가 존재하지 않습니다.');
+    }
+
+    const city = await this.eventRepository.getCityById(payload.cityId);
+
+    if (!city) {
+      throw new NotFoundException('city가 존재하지 않습니다.');
+    }
+    
 
     if (event.startTime < new Date()) {
       throw new ConflictException('이미 시작된 이벤트는 수정할 수 없습니다.');
     }
 
-    if (event.endTime < new Date()) {
-      throw new ConflictException('이미 종료된 이벤트는 수정할 수 없습니다.');
-    }
+    
     if (
-      !payload.startTime ||
-      !payload.endTime ||
       payload.startTime > payload.endTime
     ) {
       throw new ConflictException(
@@ -230,11 +240,7 @@ export class EventService {
       maxPeople: payload.maxPeople,
     };
 
-    const eventpayload = await this.eventRepository.getEventById(eventId);
-
-    if (!eventpayload || event.hostId !== eventpayload.hostId) {
-      throw new ConflictException('host만 수정할 수 있습니다.');
-    }
+    
 
     if (event.startTime < new Date()) {
       throw new ConflictException('이미 시작된 이벤트는 수정할 수 없습니다.');
@@ -257,6 +263,33 @@ export class EventService {
         '시작 시간이 현재 시간보다 빠르게 수정할 수 없습니다.',
       );
     }
+    
+    if(!payload.maxPeople || payload.maxPeople<1){
+      throw new ConflictException('maxPeople은 1이상이어야 합니다.');
+    }
+
+    if(payload.categoryId){
+      const category = await this.eventRepository.getCategoryById(
+        payload.categoryId,
+      );
+
+      if (!category) {
+        throw new NotFoundException('category가 존재하지 않습니다.');
+      }
+    }
+
+    if(payload.cityId){
+      const city = await this.eventRepository.getCityById(payload.cityId);
+
+      if (!city) {
+        throw new NotFoundException('city가 존재하지 않습니다.');
+      }
+    }
+    
+
+
+
+
 
     const updatedEvent = await this.eventRepository.updateEvent(
       eventId,
@@ -265,4 +298,35 @@ export class EventService {
 
     return EventDto.from(updatedEvent);
   }
+
+  async deleteEvent(eventId: number): Promise<void> {
+    const event = await this.eventRepository.getEventById(eventId);
+
+    if (!event) {
+      throw new NotFoundException('Event가 존재하지 않습니다.');
+    }
+
+
+    if (event.startTime < new Date()) {
+      throw new ConflictException('이미 시작된 이벤트는 삭제할 수 없습니다.');
+    }
+
+
+
+
+    await this.eventRepository.deleteEventJoin(eventId);
+
+    await this.eventRepository.deleteEvent(eventId);
+  }
+
+
+
+
+
+
+
+
+
+
+
 }

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -141,7 +141,6 @@ export class EventService {
     if (!event) {
       throw new NotFoundException('Event가 존재하지 않습니다.');
     }
-    
 
     const updateData: UpdateEventData = {
       title: payload.title,
@@ -153,7 +152,7 @@ export class EventService {
       maxPeople: payload.maxPeople,
     };
 
-    if(payload.maxPeople<1){
+    if (payload.maxPeople < 1) {
       throw new ConflictException('maxPeople은 1이상이어야 합니다.');
     }
 
@@ -170,16 +169,12 @@ export class EventService {
     if (!city) {
       throw new NotFoundException('city가 존재하지 않습니다.');
     }
-    
 
     if (event.startTime < new Date()) {
       throw new ConflictException('이미 시작된 이벤트는 수정할 수 없습니다.');
     }
 
-    
-    if (
-      payload.startTime > payload.endTime
-    ) {
+    if (payload.startTime > payload.endTime) {
       throw new ConflictException(
         '시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.',
       );
@@ -240,8 +235,6 @@ export class EventService {
       maxPeople: payload.maxPeople,
     };
 
-    
-
     if (event.startTime < new Date()) {
       throw new ConflictException('이미 시작된 이벤트는 수정할 수 없습니다.');
     }
@@ -263,12 +256,12 @@ export class EventService {
         '시작 시간이 현재 시간보다 빠르게 수정할 수 없습니다.',
       );
     }
-    
-    if(!payload.maxPeople || payload.maxPeople<1){
+
+    if (!payload.maxPeople || payload.maxPeople < 1) {
       throw new ConflictException('maxPeople은 1이상이어야 합니다.');
     }
 
-    if(payload.categoryId){
+    if (payload.categoryId) {
       const category = await this.eventRepository.getCategoryById(
         payload.categoryId,
       );
@@ -278,18 +271,13 @@ export class EventService {
       }
     }
 
-    if(payload.cityId){
+    if (payload.cityId) {
       const city = await this.eventRepository.getCityById(payload.cityId);
 
       if (!city) {
         throw new NotFoundException('city가 존재하지 않습니다.');
       }
     }
-    
-
-
-
-
 
     const updatedEvent = await this.eventRepository.updateEvent(
       eventId,
@@ -306,27 +294,12 @@ export class EventService {
       throw new NotFoundException('Event가 존재하지 않습니다.');
     }
 
-
     if (event.startTime < new Date()) {
       throw new ConflictException('이미 시작된 이벤트는 삭제할 수 없습니다.');
     }
-
-
-
 
     await this.eventRepository.deleteEventJoin(eventId);
 
     await this.eventRepository.deleteEvent(eventId);
   }
-
-
-
-
-
-
-
-
-
-
-
 }

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -12,6 +12,7 @@ import { EventQuery } from './query/event.query';
 import { EventParticipantPayload } from './payload/create-eventJoin.payload';
 import { UpdateEventData } from './type/update-event-data.type';
 import { PatchUpdateEventPayload } from './payload/patch-update-event.payload';
+import { PutUpdateEventPayload } from './payload/put-update-event.payload';
 
 @Injectable()
 export class EventService {
@@ -131,6 +132,68 @@ export class EventService {
     await this.eventRepository.outEvent(eventId, userId);
   }
 
+  async putUpdateEvent(
+    eventId: number,
+    payload: PutUpdateEventPayload,
+  ): Promise<EventDto> {
+    const event = await this.eventRepository.getEventById(eventId);
+
+    if (!event) {
+      throw new NotFoundException('Event가 존재하지 않습니다.');
+    }
+
+    const updateData: UpdateEventData = {
+      title: payload.title,
+      description: payload.description,
+      categoryId: payload.categoryId,
+      cityId: payload.cityId,
+      startTime: payload.startTime,
+      endTime: payload.endTime,
+      maxPeople: payload.maxPeople,
+    };
+    
+
+    const eventpayload = await this.eventRepository.getEventById(eventId);
+
+
+    if (!eventpayload || event.hostId !== eventpayload.hostId) {
+      throw new ConflictException('host만 수정할 수 있습니다.');
+    }
+
+    if (event.startTime < new Date()) {
+      throw new ConflictException('이미 시작된 이벤트는 수정할 수 없습니다.');
+    }
+
+    if (event.endTime < new Date()) {
+      throw new ConflictException('이미 종료된 이벤트는 수정할 수 없습니다.');
+    }
+    if (!payload.startTime || !payload.endTime || payload.startTime > payload.endTime) {
+      throw new ConflictException(
+        '시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.',
+      )
+    }
+    if(payload.startTime < new Date()) {
+      throw new ConflictException(
+        '시작 시간이 현재 시간보다 빠르게 수정할 수 없습니다.',
+      );
+    }
+
+
+
+    const updatedEvent = await this.eventRepository.updateEvent(
+      eventId,
+      updateData,
+    );
+
+
+    return EventDto.from(updatedEvent);
+  }
+
+
+
+
+
+
   async patchUpdateEvent(
     eventId: number,
     payload: PatchUpdateEventPayload,
@@ -175,10 +238,7 @@ export class EventService {
       maxPeople: payload.maxPeople,
     };
 
-    const updatedEvent = await this.eventRepository.updateEvent(
-      eventId,
-      updateData,
-    );
+    
     
     const eventpayload = await this.eventRepository.getEventById(eventId);
 
@@ -205,6 +265,11 @@ export class EventService {
       );
     }
 
+
+    const updatedEvent = await this.eventRepository.updateEvent(
+      eventId,
+      updateData,
+    );
 
 
     return EventDto.from(updatedEvent);

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -151,10 +151,8 @@ export class EventService {
       endTime: payload.endTime,
       maxPeople: payload.maxPeople,
     };
-    
 
     const eventpayload = await this.eventRepository.getEventById(eventId);
-
 
     if (!eventpayload || event.hostId !== eventpayload.hostId) {
       throw new ConflictException('host만 수정할 수 있습니다.');
@@ -167,59 +165,54 @@ export class EventService {
     if (event.endTime < new Date()) {
       throw new ConflictException('이미 종료된 이벤트는 수정할 수 없습니다.');
     }
-    if (!payload.startTime || !payload.endTime || payload.startTime > payload.endTime) {
+    if (
+      !payload.startTime ||
+      !payload.endTime ||
+      payload.startTime > payload.endTime
+    ) {
       throw new ConflictException(
         '시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.',
-      )
+      );
     }
-    if(payload.startTime < new Date()) {
+    if (payload.startTime < new Date()) {
       throw new ConflictException(
         '시작 시간이 현재 시간보다 빠르게 수정할 수 없습니다.',
       );
     }
-
-
 
     const updatedEvent = await this.eventRepository.updateEvent(
       eventId,
       updateData,
     );
 
-
     return EventDto.from(updatedEvent);
   }
-
-
-
-
-
 
   async putUpdateEvent(
     eventId: number,
     payload: PutUpdateEventPayload,
   ): Promise<EventDto> {
-    if(payload.title === null ) {
+    if (payload.title === null) {
       throw new BadRequestException('title은 null이 될 수 없습니다.');
     }
-    if(payload.description === null ) {
+    if (payload.description === null) {
       throw new BadRequestException('description은 null이 될 수 없습니다.');
     }
-    if(payload.categoryId === null ) {
+    if (payload.categoryId === null) {
       throw new BadRequestException('categoryId은 null이 될 수 없습니다.');
     }
-    if(payload.cityId === null ) {
+    if (payload.cityId === null) {
       throw new BadRequestException('cityId은 null이 될 수 없습니다.');
     }
-    if(payload.startTime === null ) {
+    if (payload.startTime === null) {
       throw new BadRequestException('startTime은 null이 될 수 없습니다.');
     }
-    if(payload.endTime === null ) {
+    if (payload.endTime === null) {
       throw new BadRequestException('endTime은 null이 될 수 없습니다.');
     }
-    if(payload.maxPeople === null ) {
+    if (payload.maxPeople === null) {
       throw new BadRequestException('maxPeople은 null이 될 수 없습니다.');
     }
-
 
     const event = await this.eventRepository.getEventById(eventId);
 
@@ -237,10 +230,7 @@ export class EventService {
       maxPeople: payload.maxPeople,
     };
 
-    
-
     const eventpayload = await this.eventRepository.getEventById(eventId);
-
 
     if (!eventpayload || event.hostId !== eventpayload.hostId) {
       throw new ConflictException('host만 수정할 수 있습니다.');
@@ -253,30 +243,26 @@ export class EventService {
     if (event.endTime < new Date()) {
       throw new ConflictException('이미 종료된 이벤트는 수정할 수 없습니다.');
     }
-    if (!payload.startTime || !payload.endTime || payload.startTime > payload.endTime) {
+    if (
+      !payload.startTime ||
+      !payload.endTime ||
+      payload.startTime > payload.endTime
+    ) {
       throw new ConflictException(
         '시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.',
-      )
+      );
     }
-    if(payload.startTime < new Date()) {
+    if (payload.startTime < new Date()) {
       throw new ConflictException(
         '시작 시간이 현재 시간보다 빠르게 수정할 수 없습니다.',
       );
     }
-
 
     const updatedEvent = await this.eventRepository.updateEvent(
       eventId,
       updateData,
     );
 
-
     return EventDto.from(updatedEvent);
-  
   }
 }
-
-
-
-
-

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -250,18 +250,20 @@ export class EventService {
       throw new ConflictException('이미 종료된 이벤트는 수정할 수 없습니다.');
     }
     if (
-      !payload.startTime ||
-      !payload.endTime ||
-      payload.startTime > payload.endTime
-    ) {
-      throw new ConflictException(
-        '시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.',
-      );
+      !payload.startTime && payload.endTime) {
+        if( payload.endTime <event.startTime){
+          throw new ConflictException('시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.');
+        }
+      }
+    if (payload.startTime && !payload.endTime) {
+      if( payload.startTime >event.endTime){
+        throw new ConflictException('시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.');
+      }
     }
-    if (payload.startTime < new Date()) {
-      throw new ConflictException(
-        '시작 시간이 현재 시간보다 빠르게 수정할 수 없습니다.',
-      );
+    if(payload.startTime && payload.endTime){
+      if( payload.startTime >payload.endTime){
+        throw new ConflictException('시작 시간이 끝나는 시간보다 늦게 수정할 수 없습니다.');
+      }
     }
     
     if(!payload.maxPeople || payload.maxPeople<1){

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -188,9 +188,9 @@ export class EventService {
     return EventDto.from(updatedEvent);
   }
 
-  async putUpdateEvent(
+  async patchUpdateEvent(
     eventId: number,
-    payload: PutUpdateEventPayload,
+    payload: PatchUpdateEventPayload,
   ): Promise<EventDto> {
     if (payload.title === null) {
       throw new BadRequestException('title은 null이 될 수 없습니다.');

--- a/src/event/event.service.ts
+++ b/src/event/event.service.ts
@@ -84,6 +84,12 @@ export class EventService {
       userId,
       eventId,
     );
+    const user = await this.eventRepository.getUserById(userId);
+
+    if (!user) {
+      throw new NotFoundException('존재하지 않는 user입니다.');
+    }
+
     if (isUserJoinedEvent) {
       throw new ConflictException('해당 유저가 이미 참가한 이벤트입니다.');
     }
@@ -112,6 +118,12 @@ export class EventService {
       userId,
       eventId,
     );
+    const user = await this.eventRepository.getUserById(userId);
+
+    if (!user) {
+      throw new NotFoundException('존재하지 않는 user입니다.');
+    }
+
     if (!isUserJoinedEvent) {
       throw new ConflictException('해당 유저가 참가하지 않은 이벤트입니다.');
     }

--- a/src/event/payload/patch-update-event.payload.ts
+++ b/src/event/payload/patch-update-event.payload.ts
@@ -1,0 +1,66 @@
+import { IsDate,IsInt, IsOptional, IsString, Max, Min } from 'class-validator';    
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+
+export class PatchUpdateEventPayload {
+    @IsOptional()
+    @IsString()
+    @ApiPropertyOptional({
+        description: '모임 이름',
+        type: String,
+    })
+    title?: string | null;
+
+    @IsOptional()
+    @IsString()
+    @ApiPropertyOptional({
+        description: '모임 설명',
+        type: String,
+    })
+    description?: string | null;
+
+    @IsOptional()
+    @IsInt()
+    @ApiPropertyOptional({
+        description: '카테고리 ID',
+        type: Number,
+    })
+    categoryId?: number | null;
+
+    @IsOptional()
+    @IsInt()
+    @ApiPropertyOptional({
+        description: '도시 ID',
+        type: Number,
+    })
+    cityId?: number | null;
+
+    @IsOptional()
+    @IsDate()
+    @Type(() => Date)
+    @ApiPropertyOptional({
+        description: '시작 시간',
+        type: Date,
+    })
+    startTime?: Date | null;
+
+    @IsOptional()
+    @IsDate()
+    @Type(() => Date)
+    @ApiPropertyOptional({
+        description: '종료 시간',
+        type: Date,
+    })
+    endTime?: Date | null;
+
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @ApiPropertyOptional({
+        description: '최대 인원',
+        type: Number,
+    })
+    maxPeople?: number | null;
+
+
+}

--- a/src/event/payload/patch-update-event.payload.ts
+++ b/src/event/payload/patch-update-event.payload.ts
@@ -1,66 +1,64 @@
-import { IsDate,IsInt, IsOptional, IsString, Max, Min } from 'class-validator';    
+import { IsDate, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 export class PatchUpdateEventPayload {
-    @IsOptional()
-    @IsString()
-    @ApiPropertyOptional({
-        description: '모임 이름',
-        type: String,
-    })
-    title?: string | null;
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: '모임 이름',
+    type: String,
+  })
+  title?: string | null;
 
-    @IsOptional()
-    @IsString()
-    @ApiPropertyOptional({
-        description: '모임 설명',
-        type: String,
-    })
-    description?: string | null;
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: '모임 설명',
+    type: String,
+  })
+  description?: string | null;
 
-    @IsOptional()
-    @IsInt()
-    @ApiPropertyOptional({
-        description: '카테고리 ID',
-        type: Number,
-    })
-    categoryId?: number | null;
+  @IsOptional()
+  @IsInt()
+  @ApiPropertyOptional({
+    description: '카테고리 ID',
+    type: Number,
+  })
+  categoryId?: number | null;
 
-    @IsOptional()
-    @IsInt()
-    @ApiPropertyOptional({
-        description: '도시 ID',
-        type: Number,
-    })
-    cityId?: number | null;
+  @IsOptional()
+  @IsInt()
+  @ApiPropertyOptional({
+    description: '도시 ID',
+    type: Number,
+  })
+  cityId?: number | null;
 
-    @IsOptional()
-    @IsDate()
-    @Type(() => Date)
-    @ApiPropertyOptional({
-        description: '시작 시간',
-        type: Date,
-    })
-    startTime?: Date | null;
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  @ApiPropertyOptional({
+    description: '시작 시간',
+    type: Date,
+  })
+  startTime?: Date | null;
 
-    @IsOptional()
-    @IsDate()
-    @Type(() => Date)
-    @ApiPropertyOptional({
-        description: '종료 시간',
-        type: Date,
-    })
-    endTime?: Date | null;
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  @ApiPropertyOptional({
+    description: '종료 시간',
+    type: Date,
+  })
+  endTime?: Date | null;
 
-    @IsOptional()
-    @IsInt()
-    @Min(1)
-    @ApiPropertyOptional({
-        description: '최대 인원',
-        type: Number,
-    })
-    maxPeople?: number | null;
-
-
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @ApiPropertyOptional({
+    description: '최대 인원',
+    type: Number,
+  })
+  maxPeople?: number | null;
 }

--- a/src/event/payload/put-update-event.payload.ts
+++ b/src/event/payload/put-update-event.payload.ts
@@ -1,0 +1,66 @@
+import {ApiProperty, ApiPropertyOptional} from '@nestjs/swagger';
+import { IsDate,IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class PutUpdateEventPayload {
+    @IsOptional()
+    @IsString()
+    @ApiPropertyOptional({
+        description: '모임 이름',
+        type: String,
+    })
+    title!: string;
+
+    @IsOptional()
+    @IsString()
+    @ApiPropertyOptional({
+        description: '모임 설명',
+        type: String,
+    })
+    description!: string;
+
+    @IsOptional()
+    @IsInt()
+    @ApiPropertyOptional({
+        description: '카테고리 ID',
+        type: Number,
+    })
+    categoryId!: number ;
+
+    @IsOptional()
+    @IsInt()
+    @ApiPropertyOptional({
+        description: '도시 ID',
+        type: Number,
+    })
+    cityId!: number ;
+
+    @IsOptional()
+    @IsDate()
+    @Type(() => Date)
+    @ApiPropertyOptional({
+        description: '시작 시간',
+        type: Date,
+    })
+    startTime!: Date;
+
+    @IsOptional()
+    @IsDate()
+    @Type(() => Date)
+    @ApiPropertyOptional({
+        description: '종료 시간',
+        type: Date,
+    })
+    endTime!: Date;
+
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @ApiPropertyOptional({
+        description: '최대 인원',
+        type: Number,
+    })
+    maxPeople!: number;
+
+
+}

--- a/src/event/payload/put-update-event.payload.ts
+++ b/src/event/payload/put-update-event.payload.ts
@@ -3,7 +3,6 @@ import { IsDate, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class PutUpdateEventPayload {
-  
   @IsString()
   @ApiPropertyOptional({
     description: '모임 이름',
@@ -11,7 +10,6 @@ export class PutUpdateEventPayload {
   })
   title!: string;
 
-  
   @IsString()
   @ApiPropertyOptional({
     description: '모임 설명',
@@ -19,7 +17,6 @@ export class PutUpdateEventPayload {
   })
   description!: string;
 
-  
   @IsInt()
   @ApiPropertyOptional({
     description: '카테고리 ID',
@@ -27,7 +24,6 @@ export class PutUpdateEventPayload {
   })
   categoryId!: number;
 
-  
   @IsInt()
   @ApiPropertyOptional({
     description: '도시 ID',
@@ -35,7 +31,6 @@ export class PutUpdateEventPayload {
   })
   cityId!: number;
 
-  
   @IsDate()
   @Type(() => Date)
   @ApiPropertyOptional({
@@ -44,7 +39,6 @@ export class PutUpdateEventPayload {
   })
   startTime!: Date;
 
-  
   @IsDate()
   @Type(() => Date)
   @ApiPropertyOptional({
@@ -53,7 +47,6 @@ export class PutUpdateEventPayload {
   })
   endTime!: Date;
 
-  
   @IsInt()
   @Min(1)
   @ApiPropertyOptional({

--- a/src/event/payload/put-update-event.payload.ts
+++ b/src/event/payload/put-update-event.payload.ts
@@ -1,66 +1,64 @@
-import {ApiProperty, ApiPropertyOptional} from '@nestjs/swagger';
-import { IsDate,IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDate, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class PutUpdateEventPayload {
-    @IsOptional()
-    @IsString()
-    @ApiPropertyOptional({
-        description: '모임 이름',
-        type: String,
-    })
-    title!: string;
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: '모임 이름',
+    type: String,
+  })
+  title!: string;
 
-    @IsOptional()
-    @IsString()
-    @ApiPropertyOptional({
-        description: '모임 설명',
-        type: String,
-    })
-    description!: string;
+  @IsOptional()
+  @IsString()
+  @ApiPropertyOptional({
+    description: '모임 설명',
+    type: String,
+  })
+  description!: string;
 
-    @IsOptional()
-    @IsInt()
-    @ApiPropertyOptional({
-        description: '카테고리 ID',
-        type: Number,
-    })
-    categoryId!: number ;
+  @IsOptional()
+  @IsInt()
+  @ApiPropertyOptional({
+    description: '카테고리 ID',
+    type: Number,
+  })
+  categoryId!: number;
 
-    @IsOptional()
-    @IsInt()
-    @ApiPropertyOptional({
-        description: '도시 ID',
-        type: Number,
-    })
-    cityId!: number ;
+  @IsOptional()
+  @IsInt()
+  @ApiPropertyOptional({
+    description: '도시 ID',
+    type: Number,
+  })
+  cityId!: number;
 
-    @IsOptional()
-    @IsDate()
-    @Type(() => Date)
-    @ApiPropertyOptional({
-        description: '시작 시간',
-        type: Date,
-    })
-    startTime!: Date;
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  @ApiPropertyOptional({
+    description: '시작 시간',
+    type: Date,
+  })
+  startTime!: Date;
 
-    @IsOptional()
-    @IsDate()
-    @Type(() => Date)
-    @ApiPropertyOptional({
-        description: '종료 시간',
-        type: Date,
-    })
-    endTime!: Date;
+  @IsOptional()
+  @IsDate()
+  @Type(() => Date)
+  @ApiPropertyOptional({
+    description: '종료 시간',
+    type: Date,
+  })
+  endTime!: Date;
 
-    @IsOptional()
-    @IsInt()
-    @Min(1)
-    @ApiPropertyOptional({
-        description: '최대 인원',
-        type: Number,
-    })
-    maxPeople!: number;
-
-
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @ApiPropertyOptional({
+    description: '최대 인원',
+    type: Number,
+  })
+  maxPeople!: number;
 }

--- a/src/event/payload/put-update-event.payload.ts
+++ b/src/event/payload/put-update-event.payload.ts
@@ -3,7 +3,7 @@ import { IsDate, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { Type } from 'class-transformer';
 
 export class PutUpdateEventPayload {
-  @IsOptional()
+  
   @IsString()
   @ApiPropertyOptional({
     description: '모임 이름',
@@ -11,7 +11,7 @@ export class PutUpdateEventPayload {
   })
   title!: string;
 
-  @IsOptional()
+  
   @IsString()
   @ApiPropertyOptional({
     description: '모임 설명',
@@ -19,7 +19,7 @@ export class PutUpdateEventPayload {
   })
   description!: string;
 
-  @IsOptional()
+  
   @IsInt()
   @ApiPropertyOptional({
     description: '카테고리 ID',
@@ -27,7 +27,7 @@ export class PutUpdateEventPayload {
   })
   categoryId!: number;
 
-  @IsOptional()
+  
   @IsInt()
   @ApiPropertyOptional({
     description: '도시 ID',
@@ -35,7 +35,7 @@ export class PutUpdateEventPayload {
   })
   cityId!: number;
 
-  @IsOptional()
+  
   @IsDate()
   @Type(() => Date)
   @ApiPropertyOptional({
@@ -44,7 +44,7 @@ export class PutUpdateEventPayload {
   })
   startTime!: Date;
 
-  @IsOptional()
+  
   @IsDate()
   @Type(() => Date)
   @ApiPropertyOptional({
@@ -53,7 +53,7 @@ export class PutUpdateEventPayload {
   })
   endTime!: Date;
 
-  @IsOptional()
+  
   @IsInt()
   @Min(1)
   @ApiPropertyOptional({

--- a/src/event/type/update-event-data.type.ts
+++ b/src/event/type/update-event-data.type.ts
@@ -1,0 +1,9 @@
+export type UpdateEventData = {
+    title?: string;
+    description?: string;
+    categoryId?: number;
+    cityId?: number;
+    startTime?: Date;
+    endTime?: Date;
+    maxPeople?: number;
+};

--- a/src/event/type/update-event-data.type.ts
+++ b/src/event/type/update-event-data.type.ts
@@ -1,9 +1,9 @@
 export type UpdateEventData = {
-    title?: string;
-    description?: string;
-    categoryId?: number;
-    cityId?: number;
-    startTime?: Date;
-    endTime?: Date;
-    maxPeople?: number;
+  title?: string;
+  description?: string;
+  categoryId?: number;
+  cityId?: number;
+  startTime?: Date;
+  endTime?: Date;
+  maxPeople?: number;
 };

--- a/src/review/review.controller.ts
+++ b/src/review/review.controller.ts
@@ -82,12 +82,4 @@ export class ReviewController {
   ): Promise<void> {
     return this.reviewService.deleteReview(reviewId);
   }
-
-  
-
-
-
-
-
-
 }

--- a/src/review/review.controller.ts
+++ b/src/review/review.controller.ts
@@ -82,4 +82,12 @@ export class ReviewController {
   ): Promise<void> {
     return this.reviewService.deleteReview(reviewId);
   }
+
+  
+
+
+
+
+
+
 }


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Refactor
- [v ] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

이전에 제공해주신 prisma docs 의
const result = await prisma.user.update({
  where: {
    id: 11,
  },
  data: {
    posts: {
      deleteMany: {
        published: false,
      },
    },
  },
  include: {
    posts: true,
  },
})
이 부분을 사용하여 deleteEvent를 한번에 구현할 예정이었으나 update 쪽을 delete로 바꾸니 에러가 나서
eventJoin지우는 부분과 event지우는 부분을 나누어서 구현했습니다.
작동은 정상적으로 되고 있습니다.