### PR TITLE
클럽 내 이벤트에 관한 리뷰 생성, 조회, 수정, 삭제 변경

### DIFF
--- a/src/review/review.controller.ts
+++ b/src/review/review.controller.ts
@@ -36,6 +36,8 @@ export class ReviewController {
   constructor(private readonly reviewService: ReviewService) {}
 
   @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '리뷰를 생성합니다' })
   @ApiCreatedResponse({ type: ReviewDto })
   async createReview(
@@ -46,19 +48,27 @@ export class ReviewController {
   }
 
   @Get(':reviewId')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '리뷰 상세 정보를 가져옵니다' })
   @ApiOkResponse({ type: ReviewDto })
   async getReviewById(
     @Param('reviewId', ParseIntPipe) reviewId: number,
+    @CurrentUser() user: UserBaseInfo,
   ): Promise<ReviewDto> {
-    return this.reviewService.getReviewById(reviewId);
+    return this.reviewService.getReviewById(reviewId, user);
   }
 
   @Get()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
   @ApiOperation({ summary: '여러 리뷰 정보를 가져옵니다' })
   @ApiOkResponse({ type: ReviewListDto })
-  async getReviews(@Query() query: ReviewQuery): Promise<ReviewListDto> {
-    return this.reviewService.getReviews(query);
+  async getReviews(
+    @Query() query: ReviewQuery,
+    @CurrentUser() user: UserBaseInfo,
+  ): Promise<ReviewListDto> {
+    return this.reviewService.getReviews(query, user);
   }
 
   @Put(':reviewId')

--- a/src/review/review.repository.ts
+++ b/src/review/review.repository.ts
@@ -78,6 +78,21 @@ export class ReviewRepository {
 
     return !!event;
   }
+  async isUserJoinedClub(userId: number, clubId: number): Promise<boolean> {
+    const clubExist = await this.prisma.clubJoin.findUnique({
+      where: {
+        clubId_userId: {
+          clubId,
+          userId,
+        },
+        user: {
+          deletedAt: null,
+        },
+      },
+    });
+
+    return !!clubExist;
+  }
 
   async getReviewById(reviewId: number): Promise<ReviewData | null> {
     return this.prisma.review.findUnique({

--- a/src/review/review.repository.ts
+++ b/src/review/review.repository.ts
@@ -56,6 +56,18 @@ export class ReviewRepository {
     });
   }
 
+  async getUserJoinedClubs(userId: number): Promise<number[]> {
+    const clubs = await this.prisma.clubJoin.findMany({
+      where: {
+        userId,
+      },
+      select: {
+        clubId: true,
+      },
+    });
+    return clubs.map((club) => club.clubId);
+  }
+
   async getEventById(eventId: number): Promise<Event | null> {
     return this.prisma.event.findUnique({
       where: {
@@ -63,6 +75,38 @@ export class ReviewRepository {
       },
     });
   }
+  async getEventsByEventIds(eventIds: number[]): Promise<EventData[]> {
+    return this.prisma.event.findMany({
+      where: {
+        id: {
+          in: eventIds,
+        },
+      },
+      select: {
+        id: true,
+        hostId: true,
+        title: true,
+        description: true,
+        categoryId: true,
+        clubId: true,
+        eventCity: {
+          select: {
+            id: true,
+            cityId: true,
+          },
+        },
+        club: {
+          select: {
+            id: true,
+          },
+        },
+        startTime: true,
+        endTime: true,
+        maxPeople: true,
+      },
+    });
+  }
+  /*
   async getEventsIdsInClub(eventIds: number[]): Promise<number[]> {
     const events = await this.prisma.event.findMany({
       where: {
@@ -92,7 +136,7 @@ export class ReviewRepository {
       },
     });
     return events.map((event) => event.id);
-  }
+  }*/
 
   async isReviewExist(userId: number, eventId: number): Promise<boolean> {
     const review = await this.prisma.review.findUnique({

--- a/src/review/review.repository.ts
+++ b/src/review/review.repository.ts
@@ -38,7 +38,7 @@ export class ReviewRepository {
       },
     });
   }
-  async getReviewsByeventIds(eventIds: number[]): Promise<ReviewData[]> {
+  async getReviewsByEventIds(eventIds: number[]): Promise<ReviewData[]> {
     return this.prisma.review.findMany({
       where: {
         eventId: {
@@ -56,7 +56,7 @@ export class ReviewRepository {
     });
   }
 
-  async getUserJoinedClubs(userId: number): Promise<number[]> {
+  async getClubIdsOfUser(userId: number): Promise<number[]> {
     const clubs = await this.prisma.clubJoin.findMany({
       where: {
         userId,

--- a/src/review/review.repository.ts
+++ b/src/review/review.repository.ts
@@ -5,7 +5,7 @@ import { ReviewData } from './type/review-data.type';
 import { User, Event } from '@prisma/client';
 import { ReviewQuery } from './query/review.query';
 import { UpdateReviewData } from './type/update-review-data.type';
-
+import { EventData } from 'src/event/type/event-data.type';
 @Injectable()
 export class ReviewRepository {
   constructor(private readonly prisma: PrismaService) {}
@@ -38,6 +38,23 @@ export class ReviewRepository {
       },
     });
   }
+  async getReviewsByeventIds(eventIds: number[]): Promise<ReviewData[]> {
+    return this.prisma.review.findMany({
+      where: {
+        eventId: {
+          in: eventIds,
+        },
+      },
+      select: {
+        id: true,
+        userId: true,
+        eventId: true,
+        score: true,
+        title: true,
+        description: true,
+      },
+    });
+  }
 
   async getEventById(eventId: number): Promise<Event | null> {
     return this.prisma.event.findUnique({
@@ -45,6 +62,36 @@ export class ReviewRepository {
         id: eventId,
       },
     });
+  }
+  async getEventsIdsInClub(eventIds: number[]): Promise<number[]> {
+    const events = await this.prisma.event.findMany({
+      where: {
+        id: {
+          in: eventIds,
+        },
+        clubId: {
+          not: null,
+        },
+      },
+      select: {
+        id: true,
+      },
+    });
+    return events.map((event) => event.id);
+  }
+  async getEventsIdsNotInClub(eventIds: number[]): Promise<number[]> {
+    const events = await this.prisma.event.findMany({
+      where: {
+        id: {
+          in: eventIds,
+        },
+        clubId: null,
+      },
+      select: {
+        id: true,
+      },
+    });
+    return events.map((event) => event.id);
   }
 
   async isReviewExist(userId: number, eventId: number): Promise<boolean> {

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -14,6 +14,7 @@ import { PutUpdateReviewPayload } from './payload/put-update-review.payload';
 import { PatchUpdateReviewPayload } from './payload/patch-update-review.payload';
 import { UserBaseInfo } from '../auth/type/user-base-info.type';
 import { ReviewData } from './type/review-data.type';
+import { filter } from 'lodash';
 
 @Injectable()
 export class ReviewService {
@@ -43,6 +44,15 @@ export class ReviewService {
     if (!event) {
       throw new NotFoundException('Event가 존재하지 않습니다.');
     }
+    if (event.clubId) {
+      const userInClub = await this.reviewRepository.isUserJoinedClub(
+        user.id,
+        event.clubId,
+      );
+      if (!userInClub) {
+        throw new ConflictException('해당 유저가 클럽에 가입하지 않았습니다.');
+      }
+    }
 
     if (event.endTime > new Date()) {
       throw new ConflictException(
@@ -69,20 +79,69 @@ export class ReviewService {
     return ReviewDto.from(review);
   }
 
-  async getReviewById(reviewId: number): Promise<ReviewDto> {
+  async getReviewById(
+    reviewId: number,
+    user: UserBaseInfo,
+  ): Promise<ReviewDto> {
     const review = await this.reviewRepository.getReviewById(reviewId);
 
     if (!review) {
       throw new NotFoundException('Review가 존재하지 않습니다.');
     }
+    const event = await this.reviewRepository.getEventById(review.eventId);
+    if (!event) {
+      throw new NotFoundException('Event가 존재하지 않습니다.');
+    }
+    if (event.clubId) {
+      const userInClub = await this.reviewRepository.isUserJoinedClub(
+        user.id,
+        event.clubId,
+      );
+      if (!userInClub) {
+        throw new ConflictException('해당 유저가 클럽에 가입하지 않았습니다.');
+      }
+    }
 
     return ReviewDto.from(review);
   }
+  //
 
-  async getReviews(query: ReviewQuery): Promise<ReviewListDto> {
+  async getReviews(
+    query: ReviewQuery,
+    user: UserBaseInfo,
+  ): Promise<ReviewListDto> {
     const reviews = await this.reviewRepository.getReviews(query);
+    const filteredReviews = await this.filterEventReviewInUserJoinedClub(
+      reviews,
+      user,
+    );
 
-    return ReviewListDto.from(reviews);
+    return ReviewListDto.from(filteredReviews);
+  } // 내가 하고자 하는거.. 이게 보면 리뷰들 중에서도 클럽 안이벤트가 있고 그렇지 않은게 있을거야냐..
+  //리뷰를 적은 이벤트가 클럽 안에서 만들어진거면 지금 조회를 하고 있는 유저가 그 클럽 안에 속한 사람인지 확인
+
+  async filterEventReviewInUserJoinedClub(
+    reviews: ReviewData[],
+    user: UserBaseInfo,
+  ) {
+    const filteredReviews = reviews.filter(async (review) => {
+      const event = await this.reviewRepository.getEventById(review.eventId);
+      if (!event) {
+        throw new NotFoundException('Event가 존재하지 않습니다.');
+      }
+      if (event.clubId) {
+        const userInClub = await this.reviewRepository.isUserJoinedClub(
+          user.id,
+          event.clubId,
+        );
+        if (!userInClub) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    return filteredReviews;
   }
 
   async putUpdateReview(
@@ -149,6 +208,20 @@ export class ReviewService {
 
     if (!review) {
       throw new NotFoundException('Review가 존재하지 않습니다.');
+    }
+
+    const event = await this.reviewRepository.getEventById(review.eventId);
+    if (!event) {
+      throw new NotFoundException('Event가 존재하지 않습니다.');
+    }
+    if (event.clubId) {
+      const userInClub = await this.reviewRepository.isUserJoinedClub(
+        userId,
+        event.clubId,
+      );
+      if (!userInClub) {
+        throw new ConflictException('해당 유저가 클럽에 가입하지 않았습니다.');
+      }
     }
 
     if (review.userId !== userId) {


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- 어떤 목적의 작업인가요?


클럽 외 유저들은 리뷰를 생성, 조회, 수정, 삭제 할 수 없도록 했습니다. 
이게 getReviews 같은 것들은 쿼리를 받기 때문에 
리뷰를 적은 이벤트가 클럽 안에 있으면 유저와 비교해서 get할  수 있게 하였고 
이벤트가 애초에 클럽안에 없으면 당연히 get 할 수 있게 구현하였습니다.